### PR TITLE
add sitenow_map index for #default_value lookup

### DIFF
--- a/sitenow_maps.module
+++ b/sitenow_maps.module
@@ -69,7 +69,7 @@ function sitenow_maps_field_widget_form(&$form, &$form_state, $field, $instance,
         '#options' => $buildings,
         '#empty_value' => '',
         '#required' => $element['#required'],
-        '#default_value' => isset($items[$delta]['value']) ? $items[$delta]['value'] : NULL,
+        '#default_value' => isset($items[$delta]['sitenow_map']['value']) ? $items[$delta]['sitenow_map']['value'] : NULL,
       );
       break;
   }


### PR DESCRIPTION
**Problem**
No default value is being returned for sitenow_map fields, and so it looks as if no building selections are being saved when viewing a node/edit form. 

Since `sitenow_maps_field_widget_form()` uses `$element['sitenow_map']['value'] = array()` to store the widget configuration, `isset($items[$delta]['value'])` always returns FALSE and so a default value is never provided. 

**Proposed solution**
We need to check for the default value in `$items[$delta]['sitenow_map']['value']`.